### PR TITLE
Feature/string message initializer plugin

### DIFF
--- a/src/Plugin/InvokeStrategy/HandleCommandStrategy.php
+++ b/src/Plugin/InvokeStrategy/HandleCommandStrategy.php
@@ -21,7 +21,6 @@ use Prooph\Common\Messaging\HasMessageName;
  */
 class HandleCommandStrategy extends AbstractInvokeStrategy
 {
-
     /**
      * @param mixed $handler
      * @param mixed $message

--- a/src/Plugin/StringMessageInitializerPlugin.php
+++ b/src/Plugin/StringMessageInitializerPlugin.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * This file is part of the prooph/service-bus.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Date: 10/20/15 - 11:40 AM
+ */
+
+namespace Prooph\ServiceBus\Plugin;
+
+use Prooph\Common\Event\ActionEvent;
+use Prooph\Common\Event\ActionEventEmitter;
+use Prooph\Common\Event\ActionEventListenerAggregate;
+use Prooph\Common\Event\DetachAggregateHandlers;
+use Prooph\ServiceBus\MessageBus;
+
+final class StringMessageInitializerPlugin implements ActionEventListenerAggregate
+{
+    use DetachAggregateHandlers;
+
+    /**
+     * @param ActionEventEmitter $emitter
+     */
+    public function attach(ActionEventEmitter $emitter)
+    {
+        $emitter->attachListener(MessageBus::EVENT_INITIALIZE, [$this, 'onInitializeEvent']);
+    }
+
+    /**
+     * @param ActionEvent $actionEvent
+     */
+    public function onInitializeEvent(ActionEvent $actionEvent)
+    {
+        $message = $actionEvent->getParam(MessageBus::EVENT_PARAM_MESSAGE);
+
+        if (is_string($message)) {
+            $actionEvent->setParam(MessageBus::EVENT_PARAM_MESSAGE_NAME, $message);
+        }
+    }
+}

--- a/tests/Plugin/StringMessageInitializerPluginTest.php
+++ b/tests/Plugin/StringMessageInitializerPluginTest.php
@@ -1,0 +1,79 @@
+<?php
+/*
+ * This file is part of the prooph/service-bus.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Date: 20/10/15 - 20:31 PM
+ */
+
+namespace ProophTest\ServiceBus\Plugin;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Prooph\Common\Event\ActionEvent;
+use Prooph\Common\Event\ActionEventEmitter;
+use Prooph\ServiceBus\MessageBus;
+use Prooph\ServiceBus\Plugin\StringMessageInitializerPlugin;
+
+/**
+ * Class StringMessageInitializerPluginTest
+ * @package ProophTest\ServiceBus\Plugin
+ */
+final class StringMessageInitializerPluginTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_attaches_listener_on_emitter()
+    {
+        $plugin = new StringMessageInitializerPlugin;
+        $emitter = $this->prophesize(ActionEventEmitter::class);
+
+        $emitter->attachListener(MessageBus::EVENT_INITIALIZE, [$plugin, 'onInitializeEvent'])->shouldBeCalled();
+
+        $plugin->attach($emitter->reveal());
+    }
+
+    /**
+     * @test
+     */
+    public function it_sets_message_name_to_the_message_contents()
+    {
+        $actionEvent = $this->prophesize(ActionEvent::class);
+        $actionEvent->getParam(MessageBus::EVENT_PARAM_MESSAGE)->willReturn('abc');
+        $actionEvent->setParam(MessageBus::EVENT_PARAM_MESSAGE_NAME, 'abc')->shouldBeCalled();
+
+        $plugin = new StringMessageInitializerPlugin;
+        $plugin->onInitializeEvent($actionEvent->reveal());
+    }
+
+    /**
+     * @param mixed $nonStringValue
+     * @dataProvider nonStringValues
+     * @test
+     */
+    public function it_will_skip_if_the_argument_it_not_a_string($nonStringValue)
+    {
+        $actionEvent = $this->prophesize(ActionEvent::class);
+        $actionEvent->getParam(MessageBus::EVENT_PARAM_MESSAGE)->willReturn($nonStringValue);
+        $actionEvent->setParam(MessageBus::EVENT_PARAM_MESSAGE_NAME, $nonStringValue)->shouldNotBeCalled();
+
+        $plugin = new StringMessageInitializerPlugin;
+        $plugin->onInitializeEvent($actionEvent->reveal());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function nonStringValues()
+    {
+        return [
+            [new \stdClass()],
+            [[]],
+            [1.0],
+            [1],
+        ];
+    }
+}


### PR DESCRIPTION
#### What's this PR do?

When a message is dispatched and is a string the message contents will be set the to the message name so the router doesn't receive "string" as the dispatched message.

#### Any background context you want to provide?

I was using strings to represent query commands instead of making query classes. How-ever by default the router uses "get_type" on the dispatched message, this makes the router look for "string" how-ever I need to to be the original sting value I dispatched when the router asks for message name.

#### Definition of Done:
- [x] Tested in a real world application.
- [x] There appropriate test coverage.
- [ ] Documentation.