### PR TITLE
Check param message-handled and throw ex in false case

### DIFF
--- a/docs/message_bus.md
+++ b/docs/message_bus.md
@@ -104,15 +104,17 @@ After routing the message, the message bus checks if the handler was provided as
 
 ### invoke-handler / invoke-finder (optional)
 
-Having the message handler in place it's time to invoke it with the message. If the `message-handler` is a `callable` the `invoke-handler` action event is not triggered but instead
-the handler is invoked by the message bus (true for all three bus types).
+Having the message handler in place it's time to invoke it with the message. `callable` message handlers are invoked by the bus. However, the `invoke-handler` / `invoke-finder` events are always triggered.
 At this stage all three bus types behave a bit different.
 
-- CommandBus: invokes the handler with the command message, or triggers the invoke-handler action event if the handler is not a callable.
+- CommandBus: invokes the handler with the command message. A `invoke-handler` event is triggered.
 - QueryBus: much the same as the command bus but the message handler is invoked with the query message and a [deferred](https://github.com/reactphp/promise/blob/master/src/Deferred.php)
-that needs to be resolved by the message handler aka finder. If the finder is not a callable the query bus triggers a `invoke-finder` action event to indicate
+that needs to be resolved by the message handler aka finder. The query bus triggers a `invoke-finder` action event to indicate
 that a finder should be invoked and not a normal message handler.
 - EventBus: loops over all `event-listeners` and triggers the `locate-handler` and `invoke-handler` action events for each message listener.
+
+*Note: * The command and query bus have a mechanism to check if the command or query was handled. If not they throw an exception.
+The event bus does not have such a mechanism as having no listener for an event is a valid case.
 
 ### handle-error
 

--- a/src/CommandBus.php
+++ b/src/CommandBus.php
@@ -40,6 +40,7 @@ class CommandBus extends MessageBus
             if (is_callable($commandHandler)) {
                 $command        = $actionEvent->getParam(self::EVENT_PARAM_MESSAGE);
                 $commandHandler($command);
+                $actionEvent->setParam(self::EVENT_PARAM_MESSAGE_HANDLED, true);
             }
         });
 
@@ -83,6 +84,10 @@ class CommandBus extends MessageBus
 
             $actionEvent->setName(self::EVENT_INVOKE_HANDLER);
             $this->trigger($actionEvent);
+
+            if (! $actionEvent->getParam(self::EVENT_PARAM_MESSAGE_HANDLED)) {
+                throw new RuntimeException(sprintf('Command %s was not handled', $this->getMessageName($command)));
+            }
 
             $this->triggerFinalize($actionEvent);
         } catch (\Exception $ex) {

--- a/src/EventBus.php
+++ b/src/EventBus.php
@@ -39,6 +39,7 @@ class EventBus extends MessageBus
             if (is_callable($eventListener)) {
                 $event = $actionEvent->getParam(self::EVENT_PARAM_MESSAGE);
                 $eventListener($event);
+                $actionEvent->setParam(self::EVENT_PARAM_MESSAGE_HANDLED, true);
             }
         });
 

--- a/src/MessageBus.php
+++ b/src/MessageBus.php
@@ -41,6 +41,7 @@ abstract class MessageBus
     const EVENT_PARAM_MESSAGE_NAME    = 'message-name';
     const EVENT_PARAM_MESSAGE_HANDLER = 'message-handler';
     const EVENT_PARAM_EXCEPTION       = 'exception';
+    const EVENT_PARAM_MESSAGE_HANDLED = 'message-handled';
 
     /**
      * @var ActionEventEmitter
@@ -76,6 +77,7 @@ abstract class MessageBus
     protected function initialize($message, ActionEvent $actionEvent)
     {
         $actionEvent->setParam(self::EVENT_PARAM_MESSAGE, $message);
+        $actionEvent->setParam(self::EVENT_PARAM_MESSAGE_HANDLED, false);
 
         if ($message instanceof HasMessageName) {
             $actionEvent->setParam(self::EVENT_PARAM_MESSAGE_NAME, $message->messageName());

--- a/src/Plugin/InvokeStrategy/AbstractInvokeStrategy.php
+++ b/src/Plugin/InvokeStrategy/AbstractInvokeStrategy.php
@@ -64,6 +64,7 @@ abstract class AbstractInvokeStrategy implements ActionEventListenerAggregate
 
         if ($this->canInvoke($handler, $message)) {
             $this->invoke($handler, $message);
+            $e->setParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLED, true);
         }
     }
 }

--- a/src/Plugin/InvokeStrategy/FinderInvokeStrategy.php
+++ b/src/Plugin/InvokeStrategy/FinderInvokeStrategy.php
@@ -16,6 +16,7 @@ use Prooph\Common\Event\ActionEventEmitter;
 use Prooph\Common\Event\ActionEventListenerAggregate;
 use Prooph\Common\Event\DetachAggregateHandlers;
 use Prooph\Common\Messaging\HasMessageName;
+use Prooph\ServiceBus\MessageBus;
 use Prooph\ServiceBus\QueryBus;
 
 /**
@@ -57,6 +58,7 @@ final class FinderInvokeStrategy implements ActionEventListenerAggregate
 
             if (method_exists($finder, $queryName)) {
                 $finder->{$queryName}($query, $deferred);
+                $actionEvent->setParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLED, true);
             }
         }
     }

--- a/src/QueryBus.php
+++ b/src/QueryBus.php
@@ -49,8 +49,8 @@ class QueryBus extends MessageBus
             if (is_callable($finder)) {
                 $query  = $actionEvent->getParam(self::EVENT_PARAM_MESSAGE);
                 $deferred = $actionEvent->getParam(self::EVENT_PARAM_DEFERRED);
-
                 $finder($query, $deferred);
+                $actionEvent->setParam(self::EVENT_PARAM_MESSAGE_HANDLED, true);
             }
         });
 
@@ -98,6 +98,10 @@ class QueryBus extends MessageBus
 
             $actionEvent->setName(self::EVENT_INVOKE_FINDER);
             $this->trigger($actionEvent);
+
+            if (! $actionEvent->getParam(self::EVENT_PARAM_MESSAGE_HANDLED)) {
+                throw new RuntimeException(sprintf('Query %s was not handled', $this->getMessageName($query)));
+            }
 
             $this->triggerFinalize($actionEvent);
         } catch (\Exception $ex) {

--- a/tests/Container/BusFactoriesTest.php
+++ b/tests/Container/BusFactoriesTest.php
@@ -12,6 +12,7 @@
 namespace ProophTest\ServiceBus\Factory;
 
 use Interop\Container\ContainerInterface;
+use Prooph\Common\Event\ActionEvent;
 use Prooph\Common\Event\ActionEventEmitter;
 use Prooph\Common\Event\ActionEventListenerAggregate;
 use Prooph\Common\Messaging\Message;
@@ -21,6 +22,7 @@ use Prooph\ServiceBus\EventBus;
 use Prooph\ServiceBus\Container\CommandBusFactory;
 use Prooph\ServiceBus\Container\EventBusFactory;
 use Prooph\ServiceBus\Container\QueryBusFactory;
+use Prooph\ServiceBus\MessageBus;
 use Prooph\ServiceBus\Plugin\Router\RegexRouter;
 use Prooph\ServiceBus\QueryBus;
 use ProophTest\ServiceBus\TestCase;
@@ -325,6 +327,10 @@ final class BusFactoriesTest extends TestCase
         $container->has('handler_service_id')->shouldNotBeCalled();
 
         $bus = $busFactory($container->reveal());
+
+        $bus->getActionEventEmitter()->attachListener(MessageBus::EVENT_INVOKE_HANDLER, function (ActionEvent $e) {
+            $e->setParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLED, true);
+        });
 
         $bus->dispatch($message->reveal());
     }

--- a/tests/EventBusTest.php
+++ b/tests/EventBusTest.php
@@ -44,16 +44,19 @@ final class EventBusTest extends TestCase
         $somethingDone = new SomethingDone(['done' => 'bought milk']);
 
         $receivedMessage = null;
-
-        $this->eventBus->getActionEventEmitter()->attachListener(MessageBus::EVENT_ROUTE, function (ActionEvent $actionEvent) use (&$receivedMessage) {
+        $dispatchEvent = null;
+        $this->eventBus->getActionEventEmitter()->attachListener(MessageBus::EVENT_ROUTE, function (ActionEvent $actionEvent) use (&$receivedMessage, &$dispatchEvent) {
             $actionEvent->setParam(EventBus::EVENT_PARAM_EVENT_LISTENERS, [function (SomethingDone $somethingDone) use (&$receivedMessage) {
                 $receivedMessage = $somethingDone;
             }]);
+
+            $dispatchEvent = $actionEvent;
         });
 
         $this->eventBus->dispatch($somethingDone);
 
         $this->assertSame($somethingDone, $receivedMessage);
+        $this->assertTrue($dispatchEvent->getParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLED));
     }
 
     /**

--- a/tests/Plugin/InvokeStrategy/AbstractInvokeStrategyTest.php
+++ b/tests/Plugin/InvokeStrategy/AbstractInvokeStrategyTest.php
@@ -46,7 +46,7 @@ final class AbstractInvokeStrategyTest extends TestCase
     /**
      * @test
      */
-    public function it_fetches_message_and_handler_and_invokes_them_it_possible()
+    public function it_fetches_message_and_handler_and_invokes_them_if_possible()
     {
         $actionEventMock = $this->getMockForAbstractClass(ActionEvent::class);
         $actionEventMock
@@ -60,6 +60,10 @@ final class AbstractInvokeStrategyTest extends TestCase
             ->method('getParam')
             ->with(MessageBus::EVENT_PARAM_MESSAGE_HANDLER)
             ->will($this->returnValue('handler'));
+
+        $actionEventMock->expects($this->at(2))
+            ->method('setParam')
+            ->with(MessageBus::EVENT_PARAM_MESSAGE_HANDLED, true);
 
         $strategy = $this->getMockForAbstractClass(AbstractInvokeStrategy::class);
         $strategy

--- a/tests/Plugin/InvokeStrategy/FinderInvokeStrategyTest.php
+++ b/tests/Plugin/InvokeStrategy/FinderInvokeStrategyTest.php
@@ -61,5 +61,6 @@ final class FinderInvokeStrategyTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($this->actionEvent->getParam(QueryBus::EVENT_PARAM_MESSAGE), $finder->getLastMessage());
         $this->assertSame($this->actionEvent->getParam(QueryBus::EVENT_PARAM_DEFERRED), $finder->getLastDeferred());
+        $this->assertTrue($this->actionEvent->getParam(QueryBus::EVENT_PARAM_MESSAGE_HANDLED));
     }
 }

--- a/tests/QueryBusTest.php
+++ b/tests/QueryBusTest.php
@@ -48,11 +48,12 @@ final class QueryBusTest extends TestCase
         $fetchSomething = new FetchSomething(['filter' => 'todo']);
 
         $receivedMessage = null;
-
-        $this->queryBus->getActionEventEmitter()->attachListener(MessageBus::EVENT_ROUTE, function (ActionEvent $actionEvent) use (&$receivedMessage) {
+        $dispatchEvent = null;
+        $this->queryBus->getActionEventEmitter()->attachListener(MessageBus::EVENT_ROUTE, function (ActionEvent $actionEvent) use (&$receivedMessage, &$dispatchEvent) {
             $actionEvent->setParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLER, function (FetchSomething $fetchSomething, Deferred $deferred) use (&$receivedMessage) {
                 $deferred->resolve($fetchSomething);
             });
+            $dispatchEvent = $actionEvent;
         });
 
         $promise = $this->queryBus->dispatch($fetchSomething);
@@ -62,6 +63,7 @@ final class QueryBusTest extends TestCase
         });
 
         $this->assertSame($fetchSomething, $receivedMessage);
+        $this->assertTrue($dispatchEvent->getParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLED));
     }
 
     /**
@@ -278,5 +280,23 @@ final class QueryBusTest extends TestCase
         $this->assertNull($handler->getLastMessage());
         $this->assertInstanceOf(Promise::class, $promise);
         $this->assertNull($handler->getLastDeferred());
+    }
+
+    /**
+     * @test
+     * @expectedException Prooph\ServiceBus\Exception\RuntimeException
+     */
+    public function it_throws_exception_if_message_was_not_handled()
+    {
+        $this->queryBus->getActionEventEmitter()->attachListener(
+            MessageBus::EVENT_INITIALIZE,
+            function (ActionEvent $e) {
+                $e->setParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLER, new \stdClass());
+            }
+        );
+
+        $promise = $this->queryBus->dispatch('throw it');
+
+        $promise->done();
     }
 }


### PR DESCRIPTION
See #87 

A new event param was added `message-handled` which is initialized with `false` and set to true by all invoke strategies (incl. closures) after message was handled. 
The command and query bus check the param after triggering `invoke-handler` / `invoke-finder` and throw an exception if param was not set to `true`. 