### PR TITLE
added bookdown.io documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ nbproject
 .settings
 vendor
 composer.lock
+docs/html

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-PSB - ProophServiceBus
-======================
+# PSB - ProophServiceBus
 
 PHP 5.5+ lightweight message bus supporting CQRS and Micro Services
 
@@ -7,8 +6,7 @@ PHP 5.5+ lightweight message bus supporting CQRS and Micro Services
 [![Coverage Status](https://coveralls.io/repos/prooph/service-bus/badge.svg?branch=master&service=github)](https://coveralls.io/github/prooph/service-bus?branch=master)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/prooph/improoph)
 
-Messaging API
--------------
+## Messaging API
 
 prooph/service-bus is a lightweight messaging facade.
 It allows you to define the API of your model with the help of messages.
@@ -27,13 +25,11 @@ but you can also receive the same messages via CLI or from a message queue syste
 ![prooph_architecture](https://raw.githubusercontent.com/prooph/proophessor/master/docs/book/img/prooph_overview.png)
 
 
-Installation
-------------
+## Installation
 
 You can install prooph/service-bus via composer by adding `"prooph/service-bus": "~4.0"` as requirement to your composer.json.
 
-Quick Start
------------
+## Quick Start
 
 ```php
 <?php
@@ -64,33 +60,39 @@ $commandBus->dispatch($echoText);
 //Output should be: It works
 ```
 
-Documentation
--------------
+## Documentation
 
-- [Overview](docs/service_bus_system.md)
-- [Message Bus API](docs/message_bus.md)
-- [Plugins](docs/plugins.md)
-- [Async Message Producers](docs/async_message_producer.md)
-- [Framework Integration](docs/factories.md)
+Documentation is [in the doc tree](doc/), and can be compiled using [bookdown](http://bookdown.io) and [Docker](https://www.docker.com/)
 
-Support
--------
+```console
+$ docker run -it --rm -v $(pwd):/app sandrokeil/bookdown doc/bookdown.json
+$ docker run -it --rm -p 8080:8080 -v $(pwd):/app php:5.6-cli php -S 0.0.0.0:8080 -t /app/doc/html
+```
+
+or make sure bookdown is installed globally via composer and `$HOME/.composer/vendor/bin` is on your `$PATH`.
+
+```console
+$ bookdown doc/bookdown.json
+$ php -S 0.0.0.0:8080 -t doc/html/
+```
+
+Then browse to [http://localhost:8080/](http://localhost:8080/)
+
+## Support
 
 - Ask questions on [prooph-users](https://groups.google.com/forum/?hl=de#!forum/prooph) google group.
 - File issues at [https://github.com/prooph/service-bus/issues](https://github.com/prooph/service-bus/issues).
 - Say hello in the [prooph gitter](https://gitter.im/prooph/improoph) chat.
 
-Contribute
-----------
+## Contribute
 
 Please feel free to fork and extend existing or add new features and send a pull request with your changes!
 To establish a consistent code quality, please provide unit tests for all your changes and may adapt the documentation.
 
-# Dependencies
+## Dependencies
 
 Please refer to the project [composer.json](composer.json) for the list of dependencies.
 
-License
--------
+## License
 
 Released under the [New BSD License](LICENSE).

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "fabpot/php-cs-fixer": "1.7.*",
         "satooshi/php-coveralls": "dev-master",
         "container-interop/container-interop" : "^1.1",
-        "sandrokeil/interop-config": "^0.3"
+        "sandrokeil/interop-config": "^0.3",
+        "tobiju/bookdown-bootswatch-templates": "1.0.x-dev"
     },
     "suggest": {
         "prooph/event-store": "Let the EventBus dispatch persisted DomainEvents",

--- a/docs/bookdown.json
+++ b/docs/bookdown.json
@@ -1,0 +1,13 @@
+{
+  "title": "PHP Enterprise Service Bus Implementation supporting CQRS and DDD",
+  "content": [
+    {"intro": "../README.md"},
+    {"overview": "service_bus_system.md"},
+    {"message_bus": "message_bus.md"},
+    {"plugins": "plugins.md"},
+    {"async_message_producer": "async_message_producer.md"},
+    {"factories": "factories.md"}
+  ],
+  "target": "./html",
+  "template": "../vendor/tobiju/bookdown-bootswatch-templates/templates/cerulean/main.php"
+}


### PR DESCRIPTION
I've added the bookdown.io documentation and there are some issues:

1. Some links (license, composer.json, ...) are broken because they are not absolut
2. It is possible to not include the bookdown templates in require-dev, but the default template looks not pretty much. I don't know if users generates the docs by yourself if we provide online docs for gh-pages and link to them in the readme.md file.
3. I did not change the doc structure for BC but I think this is the best way

What do you think?
