### PR TITLE
Resolve #107 - Correctly detect event name in OnEventStrategy

### DIFF
--- a/src/Plugin/InvokeStrategy/OnEventStrategy.php
+++ b/src/Plugin/InvokeStrategy/OnEventStrategy.php
@@ -21,6 +21,8 @@ use Prooph\Common\Messaging\HasMessageName;
  */
 class OnEventStrategy extends AbstractInvokeStrategy
 {
+    protected $foo = 'bar';
+
     /**
      * @param mixed $handler
      * @param mixed $message
@@ -50,7 +52,7 @@ class OnEventStrategy extends AbstractInvokeStrategy
      */
     protected function determineEventName($event)
     {
-        $eventName = ($event instanceof HasMessageName)? $event->messageName() : is_object($event)? get_class($event) : gettype($event);
+        $eventName = ($event instanceof HasMessageName)? $event->messageName() : (is_object($event)? get_class($event) : gettype($event));
         return implode('', array_slice(explode('\\', $eventName), -1));
     }
 }

--- a/tests/Mock/CustomMessageWithName.php
+++ b/tests/Mock/CustomMessageWithName.php
@@ -33,6 +33,6 @@ final class CustomMessageWithName implements HasMessageName
 
     public function messageName()
     {
-        return 'Result returned by messageName()';
+        return 'Prooph\Test\ServiceBus\Mock\CustomMessageWithSomeOtherName';
     }
 }

--- a/tests/Mock/CustomMessageWithName.php
+++ b/tests/Mock/CustomMessageWithName.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * This file is part of the prooph/service-bus.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Date: 08/02/15 - 8:35 PM
+ */
+
+namespace ProophTest\ServiceBus\Mock;
+
+use Prooph\Common\Messaging\HasMessageName;
+
+/**
+ * Class CustomMessage
+ * @package ProophTest\ServiceBus\Mock
+ */
+final class CustomMessageWithName implements HasMessageName
+{
+    private $text;
+
+    public function __construct($text)
+    {
+        $this->text = $text;
+    }
+
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    public function messageName()
+    {
+        return 'Result returned by messageName()';
+    }
+}

--- a/tests/Plugin/InvokeStrategy/OnEventStrategyTest.php
+++ b/tests/Plugin/InvokeStrategy/OnEventStrategyTest.php
@@ -51,11 +51,11 @@ class OnEventStrategyTest extends TestCase
         $onEventStrategy = new OnEventStrategy();
         $customEvent = new CustomMessageWithName("I am an event with a messageName() method");
 
-        $closure = function($event) {
+        $closure = function ($event) {
             return $this->determineEventName($event);
         };
         $determineEventName = $closure->bindTo($onEventStrategy, $onEventStrategy);
 
-        $this->assertSame('Result returned by messageName()', $determineEventName($customEvent));
+        $this->assertSame('CustomMessageWithSomeOtherName', $determineEventName($customEvent));
     }
 }

--- a/tests/Plugin/InvokeStrategy/OnEventStrategyTest.php
+++ b/tests/Plugin/InvokeStrategy/OnEventStrategyTest.php
@@ -13,6 +13,7 @@ namespace ProophTest\ServiceBus\Plugin\InvokeStrategy;
 
 use Prooph\ServiceBus\Plugin\InvokeStrategy\OnEventStrategy;
 use ProophTest\ServiceBus\Mock\CustomMessage;
+use ProophTest\ServiceBus\Mock\CustomMessageWithName;
 use ProophTest\ServiceBus\Mock\MessageHandler;
 use ProophTest\ServiceBus\TestCase;
 
@@ -40,5 +41,21 @@ class OnEventStrategyTest extends TestCase
         $onEventStrategy->invoke($onEventHandler, $customEvent);
 
         $this->assertSame($customEvent, $onEventHandler->getLastMessage());
+    }
+
+    /**
+     * @test
+     */
+    public function it_determines_the_event_name_from_message_name_call_if_event_has_one()
+    {
+        $onEventStrategy = new OnEventStrategy();
+        $customEvent = new CustomMessageWithName("I am an event with a messageName() method");
+
+        $closure = function($event) {
+            return $this->determineEventName($event);
+        };
+        $determineEventName = $closure->bindTo($onEventStrategy, $onEventStrategy);
+
+        $this->assertSame('Result returned by messageName()', $determineEventName($customEvent));
     }
 }


### PR DESCRIPTION
This change fixes an issue with `OnEventStrategy` not correctly
determining the event name if a custom event returns a message name
other than its own class name through the `messageName()` method.