### PR TITLE
Exceptions are all wrapped from the command bus.

### DIFF
--- a/src/CommandBus.php
+++ b/src/CommandBus.php
@@ -60,7 +60,7 @@ class CommandBus extends MessageBus
 
     /**
      * @param mixed $command
-     * @throws \Exception
+     * @throws CommandDispatchException
      * @return void
      */
     public function dispatch($command)


### PR DESCRIPTION
Sorry PHP Storm keeps telling me I'm not annotating or catching `\Exception` when I don't need to.