### PR TITLE
update factories to interop-config 1.0, add static factory support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,26 +21,31 @@
         "CQRS",
         "DDD"
     ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
-        "php": "~5.5|~7.0",
-        "beberlei/assert": "^2.0",
-        "prooph/common" : "^3.3",
-        "react/promise" : "^2.2"
+        "php": "~5.5 || ~7.0",
+        "beberlei/assert": "^2.4",
+        "prooph/common" : "^3.7",
+        "react/promise" : "^2.2.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8",
-        "fabpot/php-cs-fixer": "1.7.*",
+        "phpunit/phpunit": "^4.8.23",
+        "fabpot/php-cs-fixer": "^1.7",
         "satooshi/php-coveralls": "^1.0",
         "container-interop/container-interop" : "^1.1",
-        "sandrokeil/interop-config": "^0.3",
-        "tobiju/bookdown-bootswatch-templates": "^0.2.0"
+        "sandrokeil/interop-config": "^1.0",
+        "tobiju/bookdown-bootswatch-templates": "^1.0"
     },
     "suggest": {
         "prooph/event-store": "Let the EventBus dispatch persisted DomainEvents",
-        "zendframework/zend-servicemanager": "Use Zf2 ServiceManager to lazy load your handlers and listeners",
+        "zendframework/zend-servicemanager": "Use Zend ServiceManager to lazy load your handlers and listeners",
         "prooph/service-bus-zfc-rbac-bridge": "Use ZfcRbac as authorization service for route and finalize guard",
         "container-interop/container-interop": "For usage of provided factories",
         "sandrokeil/interop-config": "For usage of provided factories"
+    },
+    "conflict": {
+        "sandrokeil/interop-config": "<1.0"
     },
     "autoload": {
         "psr-4": {
@@ -51,5 +56,14 @@
         "psr-4": {
             "ProophTest\\ServiceBus\\": "tests/"
         }
+    },
+    "scripts": {
+        "check": [
+            "@cs",
+            "@test"
+        ],
+        "cs": "php-cs-fixer fix -v --diff --dry-run",
+        "cs-fix": "php-cs-fixer fix -v --diff",
+        "test": "phpunit"
     }
 }

--- a/config/services.php
+++ b/config/services.php
@@ -6,5 +6,9 @@ return [
     'factories' => [
         Plugin\Guard\RouteGuard::class => Container\Plugin\Guard\RouteGuardFactory::class,
         Plugin\Guard\FinalizeGuard::class => Container\Plugin\Guard\FinalizeGuardFactory::class,
+        // static factory calls with individual config id
+        'special_command_bus' => [\Prooph\ServiceBus\Container\CommandBusFactory::class, 'special'],
+        'special_event_bus' => [\Prooph\ServiceBus\Container\EventBusFactory::class, 'special'],
+        'special_query_bus' => [\Prooph\ServiceBus\Container\QueryBusFactory::class, 'special'],
     ]
 ];

--- a/src/Container/AbstractBusFactory.php
+++ b/src/Container/AbstractBusFactory.php
@@ -13,10 +13,11 @@
 namespace Prooph\ServiceBus\Container;
 
 use Interop\Config\ConfigurationTrait;
-use Interop\Config\RequiresContainerId;
+use Interop\Config\RequiresConfigId;
 use Interop\Config\ProvidesDefaultOptions;
 use Interop\Container\ContainerInterface;
 use Prooph\Common\Messaging\MessageFactory;
+use Prooph\ServiceBus\Exception\InvalidArgumentException;
 use Prooph\ServiceBus\Exception\RuntimeException;
 use Prooph\ServiceBus\MessageBus;
 use Prooph\ServiceBus\Plugin\MessageFactoryPlugin;
@@ -28,7 +29,7 @@ use Prooph\ServiceBus\Plugin\ServiceLocatorPlugin;
  * @package Prooph\ServiceBus\Container
  * @author Alexander Miertsch <kontakt@codeliner.ws>
  */
-abstract class AbstractBusFactory implements RequiresContainerId, ProvidesDefaultOptions
+abstract class AbstractBusFactory implements RequiresConfigId, ProvidesDefaultOptions
 {
     use ConfigurationTrait;
 
@@ -47,19 +48,52 @@ abstract class AbstractBusFactory implements RequiresContainerId, ProvidesDefaul
     abstract protected function getDefaultRouterClass();
 
     /**
-     * @inheritdoc
+     * @var string
      */
-    public function vendorName()
+    private $configId;
+
+    /**
+     * Creates a new instance from a specified config, specifically meant to be used as static factory.
+     *
+     * In case you want to use another config key than provided by the factories, you can add the following factory to
+     * your config:
+     *
+     * <code>
+     * <?php
+     * return [
+     *     'prooph.service_bus.other' => [CommandBusFactory::class, 'other'],
+     * ];
+     * </code>
+     *
+     * @param string $name
+     * @param array $arguments
+     * @return mixed
+     * @throws InvalidArgumentException
+     */
+    public static function __callStatic($name, array $arguments)
     {
-        return 'prooph';
+        if (!isset($arguments[0]) || !$arguments[0] instanceof ContainerInterface) {
+            throw new InvalidArgumentException(
+                sprintf('The first argument must be of type %s', ContainerInterface::class)
+            );
+        }
+        return (new static($name))->__invoke($arguments[0]);
+    }
+
+    /**
+     * @param string $configId
+     */
+    public function __construct($configId)
+    {
+        $this->configId = $configId;
     }
 
     /**
      * @inheritdoc
      */
-    public function packageName()
+    public function dimensions()
     {
-        return 'service_bus';
+        return ['prooph', 'service_bus'];
     }
 
     /**
@@ -88,7 +122,7 @@ abstract class AbstractBusFactory implements RequiresContainerId, ProvidesDefaul
             $config = $container->get('config');
         }
 
-        $busConfig = $this->optionsWithFallback($config);
+        $busConfig = $this->optionsWithFallback($config, $this->configId);
 
         $busClass = $this->getBusClass();
 
@@ -119,13 +153,13 @@ abstract class AbstractBusFactory implements RequiresContainerId, ProvidesDefaul
      * @param ContainerInterface $container
      * @throws RuntimeException
      */
-    private function attachPlugins(MessageBus $bus, array &$utils, ContainerInterface $container)
+    private function attachPlugins(MessageBus $bus, array $utils, ContainerInterface $container)
     {
         foreach ($utils as $index => $util) {
             if (! is_string($util) || ! $container->has($util)) {
                 throw new RuntimeException(sprintf(
                     'Wrong message bus utility configured at %s. Either it is not a string or unknown by the container.',
-                    $this->vendorName() . '.service_bus.' . $this->containerId() . '.' . $index
+                    implode('.', $this->dimensions()) . '.' . $this->configId . '.' . $index
                 ));
             }
 
@@ -137,7 +171,7 @@ abstract class AbstractBusFactory implements RequiresContainerId, ProvidesDefaul
      * @param MessageBus $bus
      * @param array $routerConfig
      */
-    private function attachRouter(MessageBus $bus, array &$routerConfig)
+    private function attachRouter(MessageBus $bus, array $routerConfig)
     {
         $routerClass = isset($routerConfig['type']) ? (string)$routerConfig['type'] : $this->getDefaultRouterClass();
 

--- a/src/Container/CommandBusFactory.php
+++ b/src/Container/CommandBusFactory.php
@@ -26,9 +26,9 @@ class CommandBusFactory extends AbstractBusFactory
     /**
      * @inheritdoc
      */
-    public function containerId()
+    public function __construct($configId = 'command_bus')
     {
-        return 'command_bus';
+        parent::__construct($configId);
     }
 
     /**

--- a/src/Container/EventBusFactory.php
+++ b/src/Container/EventBusFactory.php
@@ -26,9 +26,9 @@ class EventBusFactory extends AbstractBusFactory
     /**
      * @inheritdoc
      */
-    public function containerId()
+    public function __construct($configId = 'event_bus')
     {
-        return 'event_bus';
+        parent::__construct($configId);
     }
 
     /**

--- a/src/Container/QueryBusFactory.php
+++ b/src/Container/QueryBusFactory.php
@@ -25,9 +25,9 @@ class QueryBusFactory extends AbstractBusFactory
     /**
      * @inheritdoc
      */
-    public function containerId()
+    public function __construct($configId = 'query_bus')
     {
-        return 'query_bus';
+        parent::__construct($configId);
     }
 
     /**


### PR DESCRIPTION
This PR adds support for interop-config 1.0 and adds a new feature called *static factories*. Also dependencies are updated to latest versions and Composer scripts were added.

If this is ok, I will update the other packages in the same manner. /cc @codeliner 

**Note:** We have some BC breaks of the factory methods because the interface of interop-config has changed. I think we should also mark the factories as final, because the config id (container id) is now configurable. What do you think?