### PR TITLE
Bugfix: exception is not resettable with finalize event

### DIFF
--- a/src/MessageBus.php
+++ b/src/MessageBus.php
@@ -37,6 +37,7 @@ abstract class MessageBus
     public const PRIORITY_DETECT_MESSAGE_NAME = 300000;
     public const PRIORITY_ROUTE = 200000;
     public const PRIORITY_LOCATE_HANDLER = 100000;
+    public const PRIORITY_PROMISE_REJECT = 1000;
     public const PRIORITY_INVOKE_HANDLER = 0;
 
     /**

--- a/src/QueryBus.php
+++ b/src/QueryBus.php
@@ -72,7 +72,7 @@ class QueryBus extends MessageBus
                     $actionEvent->setParam(self::EVENT_PARAM_EXCEPTION, null);
                 }
             },
-            1000
+            self::PRIORITY_PROMISE_REJECT
         );
     }
 

--- a/tests/QueryBusTest.php
+++ b/tests/QueryBusTest.php
@@ -318,4 +318,38 @@ class QueryBusTest extends TestCase
 
         $promise->done();
     }
+
+    /**
+     * @test
+     */
+    public function it_could_unset_exception_with_finalize_event(): void
+    {
+        $exceptionParamWasSet = false;
+
+        $this->queryBus->attach(
+            MessageBus::EVENT_DISPATCH,
+            function (ActionEvent $actionEvent) {
+                $actionEvent->setParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLER, function (): void {
+                    throw new \Exception('Unset me!');
+                });
+            },
+            MessageBus::PRIORITY_INITIALIZE
+        );
+
+        $this->queryBus->attach(
+            MessageBus::EVENT_FINALIZE,
+            function (ActionEvent $actionEvent) use (&$exceptionParamWasSet): void {
+                if ($actionEvent->getParam(MessageBus::EVENT_PARAM_EXCEPTION) instanceof \Throwable) {
+                    $exceptionParamWasSet = true;
+                    $actionEvent->setParam(MessageBus::EVENT_PARAM_EXCEPTION, null);
+                }
+            },
+            1
+        );
+
+        $promise = $this->queryBus->dispatch('throw an exception!');
+        $promise->done();
+
+        $this->assertTrue($exceptionParamWasSet);
+    }
 }

--- a/tests/QueryBusTest.php
+++ b/tests/QueryBusTest.php
@@ -322,7 +322,7 @@ class QueryBusTest extends TestCase
     /**
      * @test
      */
-    public function it_could_unset_exception_with_finalize_event(): void
+    public function it_could_reset_exception_before_promise_becomes_rejected(): void
     {
         $exceptionParamWasSet = false;
 
@@ -344,7 +344,7 @@ class QueryBusTest extends TestCase
                     $actionEvent->setParam(MessageBus::EVENT_PARAM_EXCEPTION, null);
                 }
             },
-            1
+            MessageBus::PRIORITY_PROMISE_REJECT + 1
         );
 
         $promise = $this->queryBus->dispatch('throw an exception!');


### PR DESCRIPTION
This PR provides a bugfix for not resettable exceptions with finalize event.

- [x] add unit test which would fail without this PR
- [x] fix the bug


/cc @prolic please confirm this as a bug