### PR TITLE
Do not process already process messages with a custom strategy

### DIFF
--- a/src/Plugin/InvokeStrategy/FinderInvokeStrategy.php
+++ b/src/Plugin/InvokeStrategy/FinderInvokeStrategy.php
@@ -24,6 +24,10 @@ class FinderInvokeStrategy extends AbstractPlugin
         $this->listenerHandlers[] = $messageBus->attach(
             QueryBus::EVENT_DISPATCH,
             function (ActionEvent $actionEvent): void {
+                if ($actionEvent->getParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLED, false)) {
+                    return;
+                }
+
                 $finder = $actionEvent->getParam(QueryBus::EVENT_PARAM_MESSAGE_HANDLER);
 
                 $query = $actionEvent->getParam(QueryBus::EVENT_PARAM_MESSAGE);

--- a/src/Plugin/InvokeStrategy/HandleCommandStrategy.php
+++ b/src/Plugin/InvokeStrategy/HandleCommandStrategy.php
@@ -23,6 +23,10 @@ class HandleCommandStrategy extends AbstractPlugin
         $this->listenerHandlers[] = $messageBus->attach(
             MessageBus::EVENT_DISPATCH,
             function (ActionEvent $actionEvent): void {
+                if ($actionEvent->getParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLED, false)) {
+                    return;
+                }
+
                 $message = $actionEvent->getParam(MessageBus::EVENT_PARAM_MESSAGE);
                 $handler = $actionEvent->getParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLER);
 

--- a/src/Plugin/InvokeStrategy/OnEventStrategy.php
+++ b/src/Plugin/InvokeStrategy/OnEventStrategy.php
@@ -24,6 +24,10 @@ final class OnEventStrategy extends AbstractPlugin
         $this->listenerHandlers[] = $messageBus->attach(
             MessageBus::EVENT_DISPATCH,
             function (ActionEvent $actionEvent): void {
+                if ($actionEvent->getParam(MessageBus::EVENT_PARAM_MESSAGE_HANDLED, false)) {
+                    return;
+                }
+
                 $message = $actionEvent->getParam(MessageBus::EVENT_PARAM_MESSAGE);
                 $handlers = $actionEvent->getParam(EventBus::EVENT_PARAM_EVENT_LISTENERS, []);
 

--- a/tests/Mock/CustomInvokableMessageHandler.php
+++ b/tests/Mock/CustomInvokableMessageHandler.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This file is part of the prooph/service-bus.
+ * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\ServiceBus\Mock;
+
+class CustomInvokableMessageHandler
+{
+    private $lastMessage;
+
+    private $invokeCounter = 0;
+
+    public function __invoke($message): void
+    {
+        $this->lastMessage = $message;
+        $this->invokeCounter++;
+    }
+
+    public function getLastMessage()
+    {
+        return $this->lastMessage;
+    }
+
+    public function getInvokeCounter(): int
+    {
+        return $this->invokeCounter;
+    }
+}


### PR DESCRIPTION
See https://github.com/prooph/service-bus/issues/156

There was no check in the InvokeStrategy if a message was already handled