### PR TITLE
avoid array_merge due to appending

### DIFF
--- a/src/Plugin/ServiceLocatorPlugin.php
+++ b/src/Plugin/ServiceLocatorPlugin.php
@@ -49,13 +49,14 @@ class ServiceLocatorPlugin extends AbstractPlugin
                 $currentEventListeners = $actionEvent->getParam(EventBus::EVENT_PARAM_EVENT_LISTENERS, []);
                 $newEventListeners = [];
 
-                foreach ($currentEventListeners as $eventListenerAlias) {
+                foreach ($currentEventListeners as $key => $eventListenerAlias) {
                     if (is_string($eventListenerAlias) && $this->serviceLocator->has($eventListenerAlias)) {
-                        $newEventListeners[] = $this->serviceLocator->get($eventListenerAlias);
+                        $newEventListeners[$key] = $this->serviceLocator->get($eventListenerAlias);
                     }
                 }
 
-                $actionEvent->setParam(EventBus::EVENT_PARAM_EVENT_LISTENERS, array_merge($currentEventListeners, $newEventListeners));
+                // merge array whilst preserving numeric keys and giving priority to newEventListeners
+                $actionEvent->setParam(EventBus::EVENT_PARAM_EVENT_LISTENERS, $newEventListeners + $currentEventListeners);
             },
             MessageBus::PRIORITY_LOCATE_HANDLER
         );


### PR DESCRIPTION
ServiceLocator does not correctly merge new listeners to list of known listeners

https://3v4l.org/ZbsuF

array_merge will" "If, however, the arrays contain numeric keys, the later value will not overwrite the original value, but will be appended"