### PR TITLE
Optionally collect listener exceptions

### DIFF
--- a/docs/message_bus.md
+++ b/docs/message_bus.md
@@ -174,6 +174,13 @@ $commandBus->attach(
 );
 ```
 
+The event bus has a listener exception collection mode. This means that you can activate the mode and the event bus will
+invoke all event listeners, catch possible exceptions and push them to a exception collection. If an exception is caught
+the event bus will throw an `Prooph\ServiceBus\Exception\EventListenerException` at the end which contains all caught listener exceptions.
+
+To enable the collection mode you can attach the plugin `Prooph\ServiceBus\Plugin\ListenerExceptionCollectionMode`.
+Detach the plugin to deactivate the mode again.
+
 2) There is a new `dispatch` event replacing all other previously existing events. It is controlled by
 event priorities instead. So if your previous plugin looked like this:
 

--- a/src/Exception/EventListenerException.php
+++ b/src/Exception/EventListenerException.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of the prooph/service-bus.
+ * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\ServiceBus\Exception;
+
+class EventListenerException extends MessageDispatchException
+{
+    /**
+     * @var \Throwable[]
+     */
+    private $exceptionCollection;
+
+    public static function collected(\Throwable ...$exceptions): self
+    {
+        $msgs = '';
+
+        foreach ($exceptions as $exception) {
+            $msgs .= $exception->getMessage() . "\n";
+        }
+
+        $self = new self("At least one event listener caused an exception. Check listener exceptions for details:\n$msgs");
+
+        $self->exceptionCollection = $exceptions;
+
+        return $self;
+    }
+
+    /**
+     * @return \Throwable[]
+     */
+    public function listenerExceptions(): array
+    {
+        return $this->exceptionCollection;
+    }
+}

--- a/src/Plugin/ListenerExceptionCollectionMode.php
+++ b/src/Plugin/ListenerExceptionCollectionMode.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * This file is part of the prooph/service-bus.
+ * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\ServiceBus\Plugin;
+
+use Prooph\ServiceBus\EventBus;
+use Prooph\ServiceBus\Exception\RuntimeException;
+use Prooph\ServiceBus\MessageBus;
+
+final class ListenerExceptionCollectionMode implements Plugin
+{
+    public function attachToMessageBus(MessageBus $messageBus): void
+    {
+        $this->assertEventBus($messageBus);
+        /** @var EventBus $messageBus */
+        $messageBus->enableCollectExceptions();
+    }
+
+    public function detachFromMessageBus(MessageBus $messageBus): void
+    {
+        $this->assertEventBus($messageBus);
+        /** @var EventBus $messageBus */
+        $messageBus->disableCollectExceptions();
+    }
+
+    private function assertEventBus(MessageBus $messageBus): void
+    {
+        if (! $messageBus instanceof EventBus) {
+            throw new RuntimeException(__CLASS__ . ' can only be attached to an event bus.');
+        }
+    }
+}

--- a/tests/Mock/AutoErrorProducer.php
+++ b/tests/Mock/AutoErrorProducer.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of the prooph/service-bus.
+ * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\ServiceBus\Mock;
+
+class AutoErrorProducer
+{
+    public function __invoke($message): void
+    {
+        $this->throwException($message);
+    }
+
+    public function throwException($message)
+    {
+        throw new \Exception('I can only throw exceptions');
+    }
+}

--- a/tests/Plugin/ListenerExceptionCollectionModeTest.php
+++ b/tests/Plugin/ListenerExceptionCollectionModeTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * This file is part of the prooph/service-bus.
+ * (c) 2014-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2015-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\ServiceBus\Plugin;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\ServiceBus\CommandBus;
+use Prooph\ServiceBus\EventBus;
+use Prooph\ServiceBus\Plugin\ListenerExceptionCollectionMode;
+
+class ListenerExceptionCollectionModeTest extends TestCase
+{
+    private $eventBus;
+
+    protected function setUp()
+    {
+        $this->eventBus = new class() extends EventBus {
+            public function isCollectExceptionsModeOn(): bool
+            {
+                return (bool) $this->collectExceptions;
+            }
+        };
+
+        $this->cut = new ListenerExceptionCollectionMode();
+    }
+
+    /**
+     * @test
+     */
+    public function it_enables_collect_exceptions_mode_if_attached_and_disables_mode_if_detached_again()
+    {
+        $plugin = new ListenerExceptionCollectionMode();
+        $plugin->attachToMessageBus($this->eventBus);
+        $this->assertTrue($this->eventBus->isCollectExceptionsModeOn());
+        $plugin->detachFromMessageBus($this->eventBus);
+        $this->assertFalse($this->eventBus->isCollectExceptionsModeOn());
+    }
+
+    /**
+     * @test
+     * @expectedException \Prooph\ServiceBus\Exception\RuntimeException
+     */
+    public function it_throws_exception_if_message_bus_is_not_an_event_bus()
+    {
+        $plugin = new ListenerExceptionCollectionMode();
+        $plugin->attachToMessageBus(new CommandBus());
+    }
+}

--- a/tests/Plugin/ListenerExceptionCollectionModeTest.php
+++ b/tests/Plugin/ListenerExceptionCollectionModeTest.php
@@ -21,7 +21,7 @@ class ListenerExceptionCollectionModeTest extends TestCase
 {
     private $eventBus;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->eventBus = new class() extends EventBus {
             public function isCollectExceptionsModeOn(): bool
@@ -36,7 +36,7 @@ class ListenerExceptionCollectionModeTest extends TestCase
     /**
      * @test
      */
-    public function it_enables_collect_exceptions_mode_if_attached_and_disables_mode_if_detached_again()
+    public function it_enables_collect_exceptions_mode_if_attached_and_disables_mode_if_detached_again(): void
     {
         $plugin = new ListenerExceptionCollectionMode();
         $plugin->attachToMessageBus($this->eventBus);
@@ -49,7 +49,7 @@ class ListenerExceptionCollectionModeTest extends TestCase
      * @test
      * @expectedException \Prooph\ServiceBus\Exception\RuntimeException
      */
-    public function it_throws_exception_if_message_bus_is_not_an_event_bus()
+    public function it_throws_exception_if_message_bus_is_not_an_event_bus(): void
     {
         $plugin = new ListenerExceptionCollectionMode();
         $plugin->attachToMessageBus(new CommandBus());


### PR DESCRIPTION
Fixes #165 

To keep BC with current message bus behavior I've added a "listener exception collection" mode to the event bus. This mode can be enabled via plugin or by extending the event bus class and overriding `EventBus::$collectExceptions` property.
My first idea was to add a config option but all three buses use the same abstract factory and I don't want to change that. IMHO the plugin achieves the same goal.