### PR TITLE
AsyncMessage now implements the Message interface

### DIFF
--- a/src/Async/AsyncMessage.php
+++ b/src/Async/AsyncMessage.php
@@ -12,9 +12,11 @@ declare(strict_types=1);
 
 namespace Prooph\ServiceBus\Async;
 
+use Prooph\Common\Messaging\Message;
+
 /**
  * This interface is used to mark messages that are to be send via an async MessageProducer
  */
-interface AsyncMessage
+interface AsyncMessage extends Message
 {
 }

--- a/tests/Container/BusFactoriesTest.php
+++ b/tests/Container/BusFactoriesTest.php
@@ -285,8 +285,7 @@ class BusFactoriesTest extends TestCase
         AbstractBusFactory $busFactory
     ): void {
         $container = $this->prophesize(ContainerInterface::class);
-        $message = $this->prophesize(Message::class);
-        $message->willImplement(AsyncMessage::class);
+        $message = $this->prophesize(AsyncMessage::class);
         $messageFactory = $this->prophesize(MessageFactory::class);
         $messageProducer = new NoopMessageProducer();
         $container->get('noop_message_producer')->willReturn($messageProducer);


### PR DESCRIPTION
`AsyncMessage` should extend the `Message` interface as it's API is expected inside of `AsyncSwitchMessageRouter`.

We're upgrading our system to use async messaging but we don't use the `DomainMessage` but we did implement `AsyncMessage` and the system fell over because we were unaware we had to implement this API.