### PR TITLE
Catch throwable and reset isDispatching

### DIFF
--- a/src/CommandBus.php
+++ b/src/CommandBus.php
@@ -74,6 +74,9 @@ class CommandBus extends MessageBus
                     $this->processCommand($command);
                 }
                 $this->isDispatching = false;
+            } catch (\Throwable $ex) {
+                $this->isDispatching = false;
+                throw $ex;
             } catch (\Exception $e) {
                 $this->isDispatching = false;
                 throw CommandDispatchException::wrap($e, $this->commandQueue);

--- a/src/CommandBus.php
+++ b/src/CommandBus.php
@@ -74,12 +74,12 @@ class CommandBus extends MessageBus
                     $this->processCommand($command);
                 }
                 $this->isDispatching = false;
-            } catch (\Throwable $ex) {
-                $this->isDispatching = false;
-                throw $ex;
             } catch (\Exception $e) {
                 $this->isDispatching = false;
                 throw CommandDispatchException::wrap($e, $this->commandQueue);
+            } catch (\Throwable $e) {
+                $this->isDispatching = false;
+                throw $e;
             }
         }
     }


### PR DESCRIPTION
We ran into trouble with command bus v5. As this version supports PHP 5.x we don't catch `\Throwable`, which is ok in most situations except the one I fixed in this PR.

Problem: 5.x command bus is used in a long-running script. We have a try catch (\Throwable $ex) around command bus dispatch and are able to handle the \Throwable without killing the script. The problem is that the command bus still thinks that it is in dispatching mode, because this mode is only turned off in case of an \Exception.

The idea here is to only fix that situation and don't refactor the old version of service-bus to support \Throwable all the way down. In v6 we catch \Throwable and people (including our project) should upgrade.