### PR TITLE
Remove abbreviation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PSB - ProophServiceBus
+# Prooph Service Bus
 
 PHP 7.1+ lightweight message bus supporting CQRS and Micro Services
 

--- a/docs/async_message_producer.md
+++ b/docs/async_message_producer.md
@@ -1,6 +1,6 @@
 # Async Message Producer
 
-Messaging becomes really interesting if you process your messages asynchronously. PSB can
+Messaging becomes really interesting if you process your messages asynchronously. Prooph Service Bus can
 hide such an asynchronous workflow behind a unified interface. You can start with synchronous message
 dispatching by routing your messages directly to message handlers and if you later want to improve response
 times you can switch to async processing on a per message basis by routing the appropriate messages to a

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,7 +1,7 @@
-# PSB Plugins
+# Prooph Service Bus Plugins
 
 Plugins extend a message bus with additional functionality.
-PSB ships with a list of useful plugins that can be mixed and matched with your own implementations:
+Prooph Service Bus ships with a list of useful plugins that can be mixed and matched with your own implementations:
 
 ## Routers
 
@@ -111,7 +111,7 @@ $router->attachToMessageBus($commandBus);
 ## Invoke Strategies
 
 An invoke strategy knows how a message handler can be invoked. You can register many invoke strategies at once depending on
-how many different handler types you are using. The best way is to choose a convention and go with it. PSB ships with the invoke strategies
+how many different handler types you are using. The best way is to choose a convention and go with it. Prooph Service Bus ships with the invoke strategies
 listed below.
 
 ### Available Strategies

--- a/docs/service_bus_system.md
+++ b/docs/service_bus_system.md
@@ -1,4 +1,4 @@
-# PSB Overview
+# Prooph Service Bus Overview
 
 prooph/service-bus acts as a messaging facade. It operates on the application layer and shields your domain model.
 In addition we also provide so-called "message producers" which connect prooph/service-bus
@@ -79,7 +79,7 @@ It is pretty straight forward.
 
 # Synchronous Versus Asynchronous Processing
 
-PSB provides both possibilities behind a unified interface.
+Prooph Service Bus provides both possibilities behind a unified interface.
 Remember the statement "Messaging means fire and forget".
 The callee never knows if the message is processed synchronously or asynchronously.
 A message can be directly routed to its handler. In this case, we talk about synchronous


### PR DESCRIPTION
While reading the documentation about Async Message Producer I was very confused by "PBS". I searched websites like abbreviations.com for several minutes before I realized the intended meaning. I suggest to remove this abbreviation to avoid confusion.

I'm not sure if you prefer "Prooph Service Bus" or "ProophServiceBus". For example prooph/event-store docs use "Prooph Event Store" while docs in other packages are using "ProophEventStore".